### PR TITLE
Add machinery for 3D pose tracking

### DIFF
--- a/pose_db_io/handle/handle.py
+++ b/pose_db_io/handle/handle.py
@@ -16,7 +16,14 @@ from pose_db_io.log import logger
 
 from .models.pose_2d import Pose2d
 from .models.pose_3d import Pose3d
+from .models.pose_track_3d import PoseTrack3d
+from .models.pose_track_3d_pose_3d_link import PoseTrack3dPose3dLink
 
+def coerce_to_uuid(uuid_like_object):
+    if isinstance(uuid_like_object, uuid.UUID):
+        return(uuid_like_object)
+    else:
+        return(uuid.UUID(uuid_like_object))
 
 class PoseHandle:
     def __init__(self, db_uri: str = None):
@@ -27,6 +34,8 @@ class PoseHandle:
         self.db: MongoDatabase = self.client.get_database("poses")
         self.poses_2d_collection: MongoCollection = self.db.get_collection("poses_2d")
         self.poses_3d_collection: MongoCollection = self.db.get_collection("poses_3d")
+        self.pose_tracks_3d_collection: MongoCollection = self.db.get_collection("pose_tracks_3d")
+        self.pose_track_3d_pose_3d_links_collection: MongoCollection = self.db.get_collection("pose_track_3d_pose_3d_links") 
 
     def insert_poses_2d(self, pose_2d_batch: List[Pose2d]):
         bulk_requests = list(map(lambda p: InsertOne(p.model_dump()), pose_2d_batch))
@@ -167,12 +176,12 @@ class PoseHandle:
         query_dict = {}
         if inference_run_ids is not None:
             query_dict["metadata.inference_run_id"] = {
-                "$in": [uuid.UUID(inference_run_id) for inference_run_id in inference_run_ids]
+                "$in": [coerce_to_uuid(inference_run_id) for inference_run_id in inference_run_ids]
             }
         if environment_id is not None:
-            query_dict["metadata.environment_id"] = uuid.UUID(environment_id)
+            query_dict["metadata.environment_id"] = coerce_to_uuid(environment_id)
         if camera_ids is not None:
-            query_dict["metadata.camera_device_id"] = {"$in": [uuid.UUID(camera_id) for camera_id in camera_ids]}
+            query_dict["metadata.camera_device_id"] = {"$in": [coerce_to_uuid(camera_id) for camera_id in camera_ids]}
         if start is not None or end is not None:
             timestamp_qualifier_dict = {}
             if start is not None:
@@ -221,7 +230,8 @@ class PoseHandle:
             pose_3d_graph_initial_edge_threshold=pose_3d_graph_initial_edge_threshold,
             pose_3d_graph_max_dispersion=pose_3d_graph_max_dispersion,
         )
-        self.insert_poses_3d(pose_3d_batch=pose_3d_objects)
+        if len(pose_3d_objects) > 0:
+            self.insert_poses_3d(pose_3d_batch=pose_3d_objects)
 
     @staticmethod
     def convert_poses_3d_dataframe_to_pose3d_objects(
@@ -373,10 +383,10 @@ class PoseHandle:
         query_dict = {}
         if inference_run_ids is not None:
             query_dict["metadata.inference_run_id"] = {
-                "$in": [uuid.UUID(inference_run_id) for inference_run_id in inference_run_ids]
+                "$in": [coerce_to_uuid(inference_run_id) for inference_run_id in inference_run_ids]
             }
         if environment_id is not None:
-            query_dict["metadata.environment_id"] = uuid.UUID(environment_id)
+            query_dict["metadata.environment_id"] = coerce_to_uuid(environment_id)
         if start is not None or end is not None:
             timestamp_qualifier_dict = {}
             if start is not None:
@@ -386,15 +396,291 @@ class PoseHandle:
             query_dict["timestamp"] = timestamp_qualifier_dict
         return query_dict
 
+    def create_pose_tracks_3d(
+        self,
+        pose_tracks_output,
+        inference_id,
+        inference_run_created_at,
+        environment_id,
+        classroom_date,
+        max_match_distance,
+        max_iterations_since_last_match,
+        centroid_position_initial_sd,
+        centroid_velocity_initial_sd,
+        reference_delta_t_seconds,
+        reference_velocity_drift,
+        position_observation_sd,
+        num_poses_per_track_min,
+    ):
+        pose_track_3d_objects = self.convert_pose_tracks_output_to_pose_track_3d_objects(
+            pose_tracks_output=pose_tracks_output,
+            inference_id=inference_id,
+            inference_run_created_at=inference_run_created_at,
+            environment_id=environment_id,
+            classroom_date=classroom_date,
+            max_match_distance=max_match_distance,
+            max_iterations_since_last_match=max_iterations_since_last_match,
+            centroid_position_initial_sd=centroid_position_initial_sd,
+            centroid_velocity_initial_sd=centroid_velocity_initial_sd,
+            reference_delta_t_seconds=reference_delta_t_seconds,
+            reference_velocity_drift=reference_velocity_drift,
+            position_observation_sd=position_observation_sd,
+            num_poses_per_track_min=num_poses_per_track_min,
+        )
+        pose_track_3d_pose_3d_link_objects = self.convert_pose_tracks_output_to_pose_track_3d_pose_3d_link_objects(
+            pose_tracks_output=pose_tracks_output,
+            inference_id=inference_id,
+            inference_run_created_at=inference_run_created_at,
+        )
+        if len(pose_track_3d_objects) > 0:
+            self.insert_pose_tracks_3d(pose_track_3d_batch=pose_track_3d_objects)
+        if len(pose_track_3d_pose_3d_link_objects) > 0:
+            self.insert_pose_track_3d_pose_3d_links(pose_track_3d_pose_3d_link_batch=pose_track_3d_pose_3d_link_objects)
+
+    @staticmethod
+    def convert_pose_tracks_output_to_pose_track_3d_objects(
+        pose_tracks_output,
+        inference_id,
+        inference_run_created_at,
+        environment_id,
+        classroom_date,
+        max_match_distance,
+        max_iterations_since_last_match,
+        centroid_position_initial_sd,
+        centroid_velocity_initial_sd,
+        reference_delta_t_seconds,
+        reference_velocity_drift,
+        position_observation_sd,
+        num_poses_per_track_min,
+    ):
+        pose_track_3d_objects = list()
+        for pose_track_3d_id, pose_track_info in pose_tracks_output.items():
+            pose_track_3d_objects.append(PoseTrack3d(**{
+                'id': pose_track_3d_id,
+                'metadata':{
+                    'inference_run_id': inference_id,
+                    'inference_run_created_at': inference_run_created_at,
+                    'environment_id': environment_id,
+                    'classroom_date': classroom_date,
+                    'start': pose_track_info['start'],
+                    'end': pose_track_info['end'],
+                    'max_match_distance': max_match_distance,
+                    'max_iterations_since_last_match': max_iterations_since_last_match,
+                    'centroid_position_initial_sd': centroid_position_initial_sd,
+                    'centroid_velocity_initial_sd': centroid_velocity_initial_sd,
+                    'reference_delta_t_seconds': reference_delta_t_seconds,
+                    'reference_velocity_drift': reference_velocity_drift,
+                    'position_observation_sd': position_observation_sd,
+                    'num_poses_per_track_min': num_poses_per_track_min,
+                }
+            }))
+        return pose_track_3d_objects
+
+    @staticmethod
+    def convert_pose_tracks_output_to_pose_track_3d_pose_3d_link_objects(
+        pose_tracks_output,
+        inference_id,
+        inference_run_created_at,
+    ):
+        pose_track_3d_pose_3d_link_objects = list()
+        for pose_track_3d_id, pose_track_info in pose_tracks_output.items():
+            for pose_3d_id in pose_track_info['pose_3d_ids']:
+                pose_track_3d_pose_3d_link_objects.append(PoseTrack3dPose3dLink(**{
+                    'metadata': {
+                        'inference_run_id': inference_id,
+                        'inference_run_created_at': inference_run_created_at,
+                    },
+                    'pose_track_3d_id': pose_track_3d_id,
+                    'pose_3d_id': pose_3d_id
+                }))
+        return pose_track_3d_pose_3d_link_objects
+
+    def insert_pose_tracks_3d(self, pose_track_3d_batch: List[PoseTrack3d]):
+        bulk_requests = list(map(lambda p: InsertOne(p.model_dump()), pose_track_3d_batch))
+        try:
+            logger.debug(f"Inserting {len(bulk_requests)} into Mongo pose_tracks_3d database...")
+            self.pose_tracks_3d_collection.bulk_write(bulk_requests, ordered=False)
+            logger.debug(f"Successfully wrote {len(bulk_requests)} records into Mongo pose_tracks_3d database...")
+        except BulkWriteError as e:
+            logger.error(f"Failed writing {len(bulk_requests)} records to Mongo pose_tracks_3d database: {e}")
+
+    def insert_pose_track_3d_pose_3d_links(self, pose_track_3d_pose_3d_link_batch: List[PoseTrack3dPose3dLink]):
+        bulk_requests = list(map(lambda p: InsertOne(p.model_dump()), pose_track_3d_pose_3d_link_batch))
+        try:
+            logger.debug(f"Inserting {len(bulk_requests)} into Mongo pose_track_3d_pose_3d_links database...")
+            self.pose_track_3d_pose_3d_links_collection.bulk_write(bulk_requests, ordered=False)
+            logger.debug(f"Successfully wrote {len(bulk_requests)} records into Mongo pose_track_3d_pose_3d_links database...")
+        except BulkWriteError as e:
+            logger.error(f"Failed writing {len(bulk_requests)} records to Mongo pose_track_3d_pose_3d_links database: {e}")
+
+    def fetch_pose_tracks_3d_dataframe(
+        self,
+        inference_run_ids=None,
+        environment_id=None,
+        start=None,
+        end=None,
+    ):
+        find_iterator = self.generate_pose_tracks_3d_find_iterator(
+            inference_run_ids=inference_run_ids,
+            environment_id=environment_id,
+            start=start,
+            end=end,
+        )
+        pose_tracks_3d_list = []
+        for pose_track_3d_raw in find_iterator:
+            pose_tracks_3d_list.append(
+                collections.OrderedDict(
+                    (
+                        ("pose_track_3d_id", str(pose_track_3d_raw["id"])),
+                        ("start", pose_track_3d_raw["metadata"]["start"]),
+                        ("end", pose_track_3d_raw["metadata"]["end"]),
+                        ("inference_run_id", str(pose_track_3d_raw["metadata"]["inference_run_id"])),
+                        ("inference_run_created_at", pose_track_3d_raw["metadata"]["inference_run_created_at"]),
+                    )
+                )
+            )
+
+        pose_tracks_3d = None
+        if len(pose_tracks_3d_list) > 0:
+            pose_tracks_3d = pd.DataFrame(pose_tracks_3d_list).sort_values("start").set_index("pose_track_3d_id")
+        return pose_tracks_3d
+
+    def fetch_pose_tracks_3d_objects(
+        self,
+        inference_run_ids=None,
+        environment_id=None,
+        start=None,
+        end=None,
+    ):
+        find_iterator = self.generate_pose_tracks_3d_find_iterator(
+            inference_run_ids=inference_run_ids,
+            environment_id=environment_id,
+            start=start,
+            end=end,
+        )
+        pose_tracks_3d_list = []
+        for pose_track_3d_raw in find_iterator:
+            pose_tracks_3d_list.append(PoseTrack3d(**pose_track_3d_raw))
+        return pose_tracks_3d_list
+
+    def generate_pose_tracks_3d_find_iterator(self, inference_run_ids=None, environment_id=None, start=None, end=None):
+        query_dict = self.generate_pose_track_3d_query_dict(
+            inference_run_ids=inference_run_ids,
+            environment_id=environment_id,
+            start=start,
+            end=end,
+        )
+        find_iterator = self.pose_tracks_3d_collection.find(query_dict)
+        return find_iterator
+
+    @staticmethod
+    def generate_pose_track_3d_query_dict(
+        inference_run_ids: Optional[Union[List[str], List[uuid.UUID]]] = None,
+        environment_id: Optional[Union[str, uuid.UUID]] = None,
+        start: Optional[datetime.datetime] = None,
+        end: Optional[datetime.datetime] = None,
+    ):
+        database_tzinfo = datetime.timezone.utc
+
+        if start is not None and start.tzinfo is None:
+            raise ValueError(
+                "generate_pose_2d_query_dict 'start' attribute must be None or timezone aware datetime object"
+            )
+
+        if end is not None and end.tzinfo is None:
+            raise ValueError(
+                "generate_pose_2d_query_dict 'end' attribute must be None or timezone aware datetime object"
+            )
+
+        query_dict = {}
+        if inference_run_ids is not None:
+            query_dict["metadata.inference_run_id"] = {
+                "$in": [coerce_to_uuid(inference_run_id) for inference_run_id in inference_run_ids]
+            }
+        if environment_id is not None:
+            query_dict["metadata.environment_id"] = coerce_to_uuid(environment_id)
+        if start is not None:
+            query_dict["metadata.end"] = {
+                "gte": start
+            }
+        if end is not None:
+            query_dict["metadata.start"] = {
+                "lt": end
+            }
+        return query_dict
+
+    def fetch_pose_track_3d_pose_3d_links_dataframe(
+        self,
+        inference_run_ids=None,
+        pose_track_3d_ids=None,
+    ):
+        find_iterator = self.generate_pose_track_3d_pose_3d_links_find_iterator(
+            inference_run_ids=inference_run_ids,
+            pose_track_3d_ids=pose_track_3d_ids,
+        )
+        pose_track_3d_pose_3d_links_list = []
+        for pose_track_3d_pose_3d_link_raw in find_iterator:
+            pose_track_3d_pose_3d_links_list.append(
+                collections.OrderedDict(
+                    (
+                        ("pose_track_3d_id", str(pose_track_3d_pose_3d_link_raw["pose_track_3d_id"])),
+                        ("pose_3d_id", str(pose_track_3d_pose_3d_link_raw["pose_3d_id"])),
+                        ("inference_run_id", str(pose_track_3d_pose_3d_link_raw["metadata"]["inference_run_id"])),
+                        ("inference_run_created_at", pose_track_3d_pose_3d_link_raw["metadata"]["inference_run_created_at"]),
+                    )
+                )
+            )
+
+        pose_track_3d_pose_3d_links = None
+        if len(pose_track_3d_pose_3d_links_list) > 0:
+            pose_track_3d_pose_3d_links = pd.DataFrame(pose_track_3d_pose_3d_links_list).set_index("pose_3d_id")
+        return pose_track_3d_pose_3d_links
+
+    def fetch_pose_track_3d_pose_3d_links_objects(
+        self,
+        inference_run_ids=None,
+        pose_track_3d_ids=None,
+    ):
+        find_iterator = self.generate_pose_track_3d_pose_3d_links_find_iterator(
+            inference_run_ids=inference_run_ids,
+            pose_track_3d_ids=pose_track_3d_ids,
+        )
+        pose_track_3d_pose_3d_links_list = []
+        for pose_track_3d_pose_3d_link_raw in find_iterator:
+            pose_track_3d_pose_3d_links_list.append(PoseTrack3dPose3dLink(**pose_track_3d_pose_3d_link_raw))
+        return pose_track_3d_pose_3d_links_list
+
+    def generate_pose_track_3d_pose_3d_links_find_iterator(self, inference_run_ids=None, pose_track_3d_ids=None):
+        query_dict = self.generate_pose_track_3d_pose_3d_link_query_dict(
+            inference_run_ids=inference_run_ids,
+            pose_track_3d_ids=pose_track_3d_ids,
+        )
+        find_iterator = self.pose_track_3d_pose_3d_links_collection.find(query_dict)
+        return find_iterator
+
+    @staticmethod
+    def generate_pose_track_3d_pose_3d_link_query_dict(
+        inference_run_ids: Optional[Union[List[str], List[uuid.UUID]]] = None,
+        pose_track_3d_ids:  Optional[Union[List[str], List[uuid.UUID]]] = None,
+    ):
+        query_dict = {}
+        if inference_run_ids is not None:
+            query_dict["metadata.inference_run_id"] = {
+                "$in": [coerce_to_uuid(inference_run_id) for inference_run_id in inference_run_ids]
+            }
+        if pose_track_3d_ids is not None:
+            query_dict["pose_track_3d_id"] = {
+                "$in": [coerce_to_uuid(pose_track_3d_id) for pose_track_3d_id in pose_track_3d_ids]
+            }
+        return query_dict
+
     @staticmethod
     def fetch_coverage_dataframe_by_environment_id(environment_id: Union[str, uuid.UUID], collection):
         pose_coverage_cursor = collection.aggregate(
             [
                 {
                     "$match": {
-                        "metadata.environment_id": environment_id
-                        if isinstance(environment_id, uuid.UUID)
-                        else uuid.UUID(environment_id)
+                        "metadata.environment_id": coerce_to_uuid(environment_id)
                     }
                 },
                 {

--- a/pose_db_io/handle/models/pose_track_3d.py
+++ b/pose_db_io/handle/models/pose_track_3d.py
@@ -1,0 +1,45 @@
+from datetime import date, datetime
+from enum import Enum
+from typing import Dict, List, Literal, Optional, Tuple
+from typing_extensions import Annotated
+import uuid
+
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, UUID4
+from pydantic.functional_validators import AfterValidator
+
+
+def rounded_float(v: float) -> float:
+    return round(v, 3)
+
+
+RoundedFloat = Annotated[float, AfterValidator(rounded_float)]
+
+
+class PoseTrack3dMetadata(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, use_enum_values=True)
+
+    inference_run_id: UUID4
+    inference_run_created_at: datetime
+    environment_id: UUID4
+    classroom_date: date
+    start: datetime
+    end: datetime
+    max_match_distance: Optional[RoundedFloat]
+    max_iterations_since_last_match: Optional[int]
+    centroid_position_initial_sd: RoundedFloat
+    centroid_velocity_initial_sd: RoundedFloat
+    reference_delta_t_seconds: RoundedFloat
+    reference_velocity_drift: RoundedFloat
+    position_observation_sd: RoundedFloat
+    num_poses_per_track_min: Optional[int]
+
+    @field_serializer("classroom_date")
+    def serialize_classroom_date(self, dt: date, _info):
+        return dt.strftime("%Y-%m-%d")
+
+
+class PoseTrack3d(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, use_enum_values=True)
+
+    id: UUID4 = Field(default_factory=uuid.uuid4)
+    metadata: PoseTrack3dMetadata

--- a/pose_db_io/handle/models/pose_track_3d_pose_3d_link.py
+++ b/pose_db_io/handle/models/pose_track_3d_pose_3d_link.py
@@ -1,0 +1,29 @@
+from datetime import date, datetime
+from enum import Enum
+from typing import Dict, List, Literal, Optional, Tuple
+from typing_extensions import Annotated
+import uuid
+
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, UUID4
+from pydantic.functional_validators import AfterValidator
+
+
+def rounded_float(v: float) -> float:
+    return round(v, 3)
+
+
+RoundedFloat = Annotated[float, AfterValidator(rounded_float)]
+
+
+class PoseTrack3dPose3dLinkMetadata(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, use_enum_values=True)
+
+    inference_run_id: UUID4
+    inference_run_created_at: datetime
+
+class PoseTrack3dPose3dLink(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, use_enum_values=True)
+
+    metadata: PoseTrack3dPose3dLinkMetadata
+    pose_track_3d_id: UUID4
+    pose_3d_id: UUID4


### PR DESCRIPTION
So the deal is: whenever we pass UUID-like objects through Pydantic, they can be strings or UUID objects and they are automatically coerced into UUID objects. However, there are several places where we send UUID-like objects directly to Mongo without passing through Pydantic (e.g., when we're building dicts for `find` or `aggregate`. In those cases, we need to explicitly coerce to UUID objects (because PyMongo does not). For now, I'm doing this with a `coerce_to_uuid()` function that I defined at the top of `handle.py`.